### PR TITLE
Fix re-connection by writing factory reset ID always after connecting. Add Bluetooth Proxy support.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -40,8 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         
         # Setup scanner and verify connection
         manager.setup()
-        if not await manager.connect_and_verify():
-            raise ConfigEntryNotReady("Failed to verify device connection")
+        await manager.ensure_connection()
         
         # Store the manager instance
         hass.data.setdefault(DOMAIN, {})

--- a/config_flow.py
+++ b/config_flow.py
@@ -79,7 +79,9 @@ class EnstoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._manager.setup()
             
             # Try to connect and authenticate the device
-            if not await self._manager.connect_and_verify():
+            try: 
+                await self._manager.ensure_connection()
+            except Exception as e:
                 return self.async_abort(
                     reason="Connection and authentication with the device failed. Please try again."
                 )


### PR DESCRIPTION
Hi, I was finally able to play with this and it sure looks promising!

I was able to find some fixes for connection robustness:
- Use generic BleakClient instead of bluetoothctl to support Bluetooth Proxy.
- Moved factory reset ID handling to connect() so that it is always done in a same way when connecting to device.
- Changed locking in connect() so that other threads calling it when characteristics are updated return immediately instead of waiting for lock while one thread is trying to re-connect. Removed _is_connecting, as it wasn't needed anymore. Connect() throws exceptions on failure to interrupt initialization and characteristic reading/writing. Catching exceptions could be improved in some places but seems to work.
- Always call pair() after connect to set encryption. It is needed at least with Bluetooth Proxy, and seemed to work also with my other BT adapter.

It is likely that all used BT adapters need to be paired separately by putting thermostat to pairing mode. Not sure about that.

Tested with one ESPHome Bluetooth Proxy and one internal Intel Bluetooth adapter in Ubuntu:
- initial pairing
- turn thermostat Off and back On while connected
- Switch BT adapters in HA by enabling/disabling them while thermostat is connected. Other adapter connects automatically.