### PR TITLE
Fix temperature boost offset range to -20..20

### DIFF
--- a/ensto_thermostat_manager.py
+++ b/ensto_thermostat_manager.py
@@ -418,8 +418,8 @@ class EnstoThermostatManager:
                 return False
 
             # Validate input values
-            if not (0 <= offset_degrees <= 50):
-                raise ValueError("Temperature offset must be between 0 and 50 degrees")
+            if not (-20 <= offset_degrees <= 20):
+                raise ValueError("Temperature offset must be between -20 and 20 degrees")
             if not (-100 <= offset_percentage <= 100):
                 raise ValueError("Percentage offset must be between -100 and 100")
             if not (0 <= duration_minutes <= 65535):  # max value for uint16

--- a/number.py
+++ b/number.py
@@ -99,8 +99,8 @@ class EnstoBoostOffsetNumber(EnstoBaseEntity, NumberEntity):
        super().__init__(manager)
        self._attr_name = f"{self._manager.device_name or self._manager.mac_address} Boost Temperature Offset"
        self._attr_unique_id = f"ensto_{self._manager.mac_address}_boost_temp_offset"
-       self._attr_native_min_value = 0
-       self._attr_native_max_value = 5
+       self._attr_native_min_value = -20
+       self._attr_native_max_value = 20
        self._attr_native_step = 0.5
        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
        self._attr_device_class = NumberDeviceClass.TEMPERATURE


### PR DESCRIPTION
Correct temperature boost offset range is from -20 to 20. I tested also with higher and lower values, but ECO16 didn't accept them. Interface doc has misleading boost offset conversion example "21,5 as 2150", as 21,5 is not a valid offset.