### PR TITLE
Update README.md with more details on process of pairing thermostat

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ Custom component to read and write data from Ensto BLE thermostats.
 ### Pairing a Thermostat
 
 1. Put the thermostat in pairing mode (hold BLE reset button >0.5 seconds until blue LED blinks)
-2. Select your thermostat from the discovered devices list
-3. Choose currency for energy calculations (stored in thermostat memory)
+2. Navigate to **Settings → Devices & services → Add Integration**
+3. Search for "Hass Ensto BLE"
+4. Select your thermostat from the discovered devices list
+5. Choose currency for energy calculations (stored in thermostat memory)
 
 ### Adding Thermostat to Dashboard
 


### PR DESCRIPTION
Add details on how to pair a thermostat (adding integration while thermostat is in pairing mode).

This was the first time for me adding a Bluetooth device (via an ESP32 as a bluetooth proxy). I somehow assumed the thermostat might be automatically discovered after installing hass_ensto_ble and would show up in the "Discovered" section. Instead the device is discovered by adding the installed integration "Hass Ensto BLE" while the thermostat is in pairing mode.

Maybe just me, but this took me on a wild goose chase, trying to figure out how to use bluetoothctl with the ESP32 proxy which is of course impossible 🙃 